### PR TITLE
deleted double-entry

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,6 @@ var express = require('express')
   , fs = require('fs')
   , path = require('path')
   , http = require('http')
-  , path = require('path')
   , passport = require('passport')
   , GithubStrategy = require('passport-github').Strategy;
 try {


### PR DESCRIPTION
deleted the double call of path = require('path')
