### PR TITLE
Zpriddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#Cloud9Hub
+# Cloud9Hub
 
-##What's this?
+## What's this?
 It's a simple interface for the Cloud 9 open source edition to easily create, use and manage multiple workspaces.
 [The Cloud9 service](https://c9.io) has a shiny and awesome dashboard interface where you can manage multiple workspaces,
 however the [open source edition](https://github.com/ajaxorg/cloud9) is a single workspace instance of Cloud9.
 
 As I like the possibility to easily start working on different workspaces, create or delete them, I created Cloud9Hub to do so.
 
-##What's Cloud9?
+## What's Cloud9?
 A full-blown IDE in your browser. It has a full terminal integration, can run and deploy code of different languages (e.g. Ruby, node.js, PHP)
 and [lots more](http://en.wikipedia.org/wiki/Cloud9_IDE#Features).
 
-##Status Quo of Cloud9Hub
+## Status Quo of Cloud9Hub
 Right now it can
 * Create new workspaces
 * Launch multiple workspace instances
@@ -24,7 +24,7 @@ Right now it can
 
 right now. These are the next steps for me to build (or you make a Pull Request with the features you want).
 
-##Installation
+## Installation
 First you will need [node.js](http://nodejs.org/), at least v0.8.
 
 Then you can try the quick install or the manual way:
@@ -53,17 +53,64 @@ Now copy the ``config.js.example`` to ``config.js`` and edit the contents:
 - Add your Github client ID and secret
 - Change your BASE_URL to your server's address (do not include the port!)
 
-##Firewall
+## Firewall
 You will need ports 3000 and 5000 to however many connections will be taking place concurrently (each session is given a different port)
 
-##Running as a daemon
+## nginx and LetsEncrypt Setup
+
+### Get HTTPS cert using [LetsEncrypt](https://letsencrypt.org/)
+```shell
+cd ~/
+git clone https://github.com/letsencrypt/letsencrypt
+cd letsencrypt
+./letsencrypt-auto certonly --standalone
+```
+Follow the directions and at the end it should say that it was sucessful. 
+
+### Install nginx and apache2-utils
+```shell
+[sudo] apt-get install nginx apache2-utils
+```
+
+### Setup htaccess password 
+```shell
+sudo htpasswd -c /etc/nginx/.htpasswd <<USERNAME>>
+```
+
+It will then ask you to enter a password. This username and password will be used when loading the c9 IDE. You will still be using github to load the cloud9hub. Maybe look into [oauth2_proxy] (https://github.com/bitly/oauth2_proxy) in the future
+
+### Move Https Certs
+```shell
+sudo mkdir /etc/nginx/certs
+sudo mkdir /etc/nginx/certs/<YOUR DOMAIN>
+sudo cp /etc/letsencrypt/live/<YOUR DOMAIN>/fullchain.pem  /etc/nginx/certs/<YOUR DOMAIN>/
+sudo cp /etc/letsencrypt/live/<YOUR DOMAIN>/privkey.pem  /etc/nginx/certs/<YOUR DOMAIN>/
+```
+
+### Setup nginx
+copy the etc.nginx.sites-available.defualt.example to /etc/nginx/sites-available/default
+```shell
+[sudo] cp etc.nginx.sites-available.defualt.example /etc/nginx/sites-available/default
+```
+Edit the file /etc/nginx/sites-available/default and add the EXT IP, SERVER HOSTNAME, PATH TO CERT, PATH TO KEY
+
+PATH TO CERT should be /etc/nginx/certs/<YOUR DOMAIN>/fullcahin.pem
+
+PATH TO KEY should be /etc/nginx/certs/<YOUR DOMAIN>/privkey.pem
+
+Restart nginx
+```shell
+[sudo] service nginx restart
+```
+
+## Running as a daemon
 If you wish to, you can run it as a daemon, so that it stays alive.
 
 To do so, I recommend [forever](https://npmjs.org/package/forever).
 
-##License
+## License
 **This project:** [MIT License](http://opensource.org/licenses/MIT), baby.
 **Cloud9 itself:** [GPL](http://www.gnu.org/licenses/gpl.html)
 
-##WARNING
+## WARNING
 This is highly insecure, experimental and it may bite.

--- a/config.js.example
+++ b/config.js.example
@@ -13,4 +13,4 @@ exports.PERMITTED_USERS = false;
 //  cert: "/path/to/ssl.pem"
 //};
 
-exports.BASE_URL = 'http://localhost';
+exports.BASE_URL = 'https://localhost';

--- a/controllers/workspaces.js
+++ b/controllers/workspaces.js
@@ -115,7 +115,7 @@ exports.destroy = function(req, res) {
         })
         .close()
       })
-      .listen(port)
+      .listen(port, '127.0.0.1')
     };
     
     var getNextAvailablePort = function(callback){
@@ -149,7 +149,7 @@ exports.destroy = function(req, res) {
             console.log("Starting " + __dirname + '/../c9/server.js for workspace ' + workspaceName + " on port " + nextFreePort);
             var workspaceDir = __dirname + '/../workspaces/' + req.user + '/' + workspaceName
             var out = fs.openSync(workspaceDir + '/.c9.log', 'a');
-            var workspace = fork(__dirname + '/../c9/server.js', ['-w', workspaceDir, '--listen', '0.0.0.0', '-p', nextFreePort, '-a', ':'], {detached: true, stdio: [out, out, out]});
+            var workspace = fork(__dirname + '/../c9/server.js', ['-w', workspaceDir, '--listen', '127.0.0.1', '-p', nextFreePort, '-a', ':'], {detached: true, stdio: [out, out, out]});
            
             req.app.get('runningWorkspaces')[req.user + '/' + workspaceName] = {
                 killTimeout: createWorkspaceKillTimeout(req, workspace, workspaceName),

--- a/etc.nginx.site-available.default.example
+++ b/etc.nginx.site-available.default.example
@@ -1,0 +1,111 @@
+# You may add here your
+# server {
+#	...
+# }
+# statements for each of your virtual hosts to this file
+
+##
+# You should look at the following URL's in order to grasp a solid understanding
+# of Nginx configuration files in order to fully unleash the power of Nginx.
+# http://wiki.nginx.org/Pitfalls
+# http://wiki.nginx.org/QuickStart
+# http://wiki.nginx.org/Configuration
+#
+# Generally, you will want to move this file somewhere, and start with a clean
+# file but keep this around for reference. Or just disable in sites-enabled.
+#
+# Please see /usr/share/doc/nginx-doc/examples/ for more detailed examples.
+##
+
+#server {
+#	listen 80 default_server;
+#	listen [::]:80 default_server ipv6only=on;
+#
+#	root /usr/share/nginx/html;
+#	index index.html index.htm;
+#
+#	# Make site accessible from http://localhost/
+#	server_name localhost;
+#
+#	location / {
+#		# First attempt to serve request as file, then
+#		# as directory, then fall back to displaying a 404.
+#		try_files $uri $uri/ =404;
+#		# Uncomment to enable naxsi on this location
+#		# include /etc/nginx/naxsi.rules
+#	}
+#
+#	# Only for nginx-naxsi used with nginx-naxsi-ui : process denied requests
+#	#location /RequestDenied {
+#	#	proxy_pass http://127.0.0.1:8080;    
+#	#}
+#
+##
+#	# redirect server error pages to the static page /50x.html
+#	#
+#	#error_page 500 502 503 504 /50x.html;
+#	#location = /50x.html {
+#	#	root /usr/share/nginx/html;
+#	#}
+#
+#	# pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+#	#
+#	#location ~ \.php$ {
+#	#	fastcgi_split_path_info ^(.+\.php)(/.+)$;
+#	#	# NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+#	#
+#	#	# With php5-cgi alone:
+#	#	fastcgi_pass 127.0.0.1:9000;
+#	#	# With php5-fpm:
+#	#	fastcgi_pass unix:/var/run/php5-fpm.sock;
+#	#	fastcgi_index index.php;
+#	#	include fastcgi_params;
+#	#}
+#
+#	# deny access to .htaccess files, if Apache's document root
+#	# concurs with nginx's one
+#	#
+#	#location ~ /\.ht {
+#	#	deny all;
+#	#}
+#}
+
+
+# HTTPS server
+#
+server {
+    listen <<EXTIP>>:3001;
+	listen <<EXTIP>>:3002;
+	listen <<EXTIP>>:3003;
+	listen <<EXTIP>>:3004;
+	listen <<EXTIP>>:3005;
+	listen <<EXTIP>>:3006;
+	listen <<EXTIP>>:3007;
+	listen <<EXTIP>>:3008;
+	listen <<EXTIP>>:3009;
+	listen <<EXTIP>>:3010;
+
+	resolver 8.8.8.8;
+    server_name <<SERVER HOSTNAME>>;
+
+    root html;
+    index index.html index.htm;
+
+    ssl on;
+    ssl_certificate <<PATH TO CERT>>;
+    ssl_certificate_key <<PATH TO KEY>>;
+
+    ssl_session_timeout 5m;
+
+    ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
+    ssl_prefer_server_ciphers on;
+
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
+
+    location / {
+        proxy_pass http://127.0.0.1:$server_port;
+    }
+}

--- a/views/includes/footer.html
+++ b/views/includes/footer.html
@@ -15,7 +15,3 @@
 <script src="/js/workspace/workspaceController.js"></script>
 <script src="/js/workspace/workspaceModule.js"></script>
 <script src="/js/app.js"></script>
-{% if (process.env.NODE_ENV == 'development') %}
-    <!-- Livereload script rendered -->
-    <script type="text/javascript" src="{{'http://' + req.host + ':35729/livereload.js'}}"></script>
-{% endif %}


### PR DESCRIPTION
I added a layer of HTTP using letsencrypt and nginx. It now requires basic auth when accessing the c9 IDE. I did not like how everything was open to the internet without even https with c9 - more so with no password if the IDE was running considering it has access to a shell. There is more that can be done - maybe using oauth2_proxy in the future. This is just a quick security improvement. Feel free to contact me if you have any questions about these changes or would like to start working together - me@zpriddy.com