### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#Cloud9Hub
+# Cloud9Hub
 
-##What's this?
+## What's this?
 It's a simple interface for the Cloud 9 open source edition to easily create, use and manage multiple workspaces.
 [The Cloud9 service](https://c9.io) has a shiny and awesome dashboard interface where you can manage multiple workspaces,
 however the [open source edition](https://github.com/ajaxorg/cloud9) is a single workspace instance of Cloud9.
 
 As I like the possibility to easily start working on different workspaces, create or delete them, I created Cloud9Hub to do so.
 
-##What's Cloud9?
+## What's Cloud9?
 A full-blown IDE in your browser. It has a full terminal integration, can run and deploy code of different languages (e.g. Ruby, node.js, PHP)
 and [lots more](http://en.wikipedia.org/wiki/Cloud9_IDE#Features).
 
-##Status Quo of Cloud9Hub
+## Status Quo of Cloud9Hub
 Right now it can
 * Create new workspaces
 * Launch multiple workspace instances
@@ -24,7 +24,7 @@ Right now it can
 
 right now. These are the next steps for me to build (or you make a Pull Request with the features you want).
 
-##Installation
+## Installation
 First you will need [node.js](http://nodejs.org/), at least v0.8.
 
 Then you can try the quick install or the manual way:
@@ -53,17 +53,17 @@ Now copy the ``config.js.example`` to ``config.js`` and edit the contents:
 - Add your Github client ID and secret
 - Change your BASE_URL to your server's address (do not include the port!)
 
-##Firewall
+## Firewall
 You will need ports 3000 and 5000 to however many connections will be taking place concurrently (each session is given a different port)
 
-##Running as a daemon
+## Running as a daemon
 If you wish to, you can run it as a daemon, so that it stays alive.
 
 To do so, I recommend [forever](https://npmjs.org/package/forever).
 
-##License
+## License
 **This project:** [MIT License](http://opensource.org/licenses/MIT), baby.
 **Cloud9 itself:** [GPL](http://www.gnu.org/licenses/gpl.html)
 
-##WARNING
+## WARNING
 This is highly insecure, experimental and it may bite.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
